### PR TITLE
fix(options): reload win_opts after tab switch of type

### DIFF
--- a/lua/scratch/init.lua
+++ b/lua/scratch/init.lua
@@ -324,6 +324,11 @@ local function update_windows()
     local cfg = make_window_config()
     vim.api.nvim_win_set_config(state.winnr, cfg.cfg_wnd)
 
+    -- Main window
+    for opt, val in pairs(config.win_opts) do
+        vim.wo[state.winnr][opt] = val
+    end
+
     update_footer()
     if state.foonr and vim.api.nvim_win_is_valid(state.foonr) then
         vim.api.nvim_win_set_config(state.foonr, cfg.cfg_foo)


### PR DESCRIPTION
Hi! I'm not sure if you're still maintaining the repo, but I wanted to push a
fix I applied for my local version.

# Issue
User's window options such as `number` and `relativenumber` are only
evaluated once when the window is opened in `open_window()`. So, when
the user switches modes using `Tab`, those options are not conserved.

# Solution
Reevaluate the `win_opts` list.

Signed-off-by: Emir Baha Yıldırım <jayshozie@gmail.com>
